### PR TITLE
Proposer interceptation

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -29,12 +29,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/sha3"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -663,4 +665,13 @@ func (c *Clique) APIs(chain consensus.ChainReader) []rpc.API {
 // Protocol implements consensus.Engine.Protocol
 func (c *Clique) Protocol() consensus.Protocol {
 	return consensus.EthProtocol
+}
+
+func (c *Clique) SubscribeCatchUpEvent(ch chan<- istanbul.CatchUpEvent) event.Subscription {
+	log.Trace("No implementado.", ch)
+	return nil
+}
+
+func (c *Clique) SendCatchUp(catchUp istanbul.CatchUpEvent) {
+	log.Trace("No implementado.", catchUp)
 }

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -668,10 +668,10 @@ func (c *Clique) Protocol() consensus.Protocol {
 }
 
 func (c *Clique) SubscribeCatchUpEvent(ch chan<- istanbul.CatchUpEvent) event.Subscription {
-	log.Trace("No implementado.", ch)
+	log.Trace("Not implemented.", ch)
 	return nil
 }
 
 func (c *Clique) SendCatchUp(catchUp istanbul.CatchUpEvent) {
-	log.Trace("No implementado.", catchUp)
+	log.Trace("Not implemented.", catchUp)
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -19,8 +19,10 @@ package consensus
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -94,6 +96,8 @@ type Engine interface {
 
 	// Protocol returns the protocol for this consensus
 	Protocol() Protocol
+
+	SubscribeCatchUpEvent(chan<- istanbul.CatchUpEvent) event.Subscription
 }
 
 // Handler should be implemented is the consensus needs to handle and send peer's message

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -97,6 +97,7 @@ type Engine interface {
 	// Protocol returns the protocol for this consensus
 	Protocol() Protocol
 
+	// FIXME: Generalize as all consensus possbile event.
 	SubscribeCatchUpEvent(chan<- istanbul.CatchUpEvent) event.Subscription
 }
 

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -27,9 +27,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	set "gopkg.in/fatih/set.v0"
 )
@@ -578,4 +581,13 @@ func AccumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		reward.Add(reward, r)
 	}
 	state.AddBalance(header.Coinbase, reward)
+}
+
+func (ethash *Ethash) SubscribeCatchUpEvent(ch chan<- istanbul.CatchUpEvent) event.Subscription {
+	log.Trace("No implementado.", ch)
+	return nil
+}
+
+func (ethash *Ethash) SendCatchUp(catchUp istanbul.CatchUpEvent) {
+	log.Trace("No implementado.", catchUp)
 }

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -584,10 +584,10 @@ func AccumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 }
 
 func (ethash *Ethash) SubscribeCatchUpEvent(ch chan<- istanbul.CatchUpEvent) event.Subscription {
-	log.Trace("No implementado.", ch)
+	log.Trace("Not implemented.", ch)
 	return nil
 }
 
 func (ethash *Ethash) SendCatchUp(catchUp istanbul.CatchUpEvent) {
-	log.Trace("No implementado.", catchUp)
+	log.Trace("Not implemented.", catchUp)
 }

--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -70,4 +70,10 @@ type Backend interface {
 
 	// HasBadBlock returns whether the block with the hash is a bad block
 	HasBadProposal(hash common.Hash) bool
+
+	// Subscribe to the events emmited when the proposer fails
+	SubscribeCatchUpEvent(ch chan<- CatchUpEvent) event.Subscription
+
+	// Send an event when the proposer fails
+	SendCatchUp(catchUp CatchUpEvent)
 }

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -98,6 +98,8 @@ type backend struct {
 
 	recentMessages *lru.ARCCache // the cache of peer's messages
 	knownMessages  *lru.ARCCache // the cache of self messages
+
+	txCachUp event.Feed
 }
 
 // Address implements istanbul.Backend.Address
@@ -309,4 +311,12 @@ func (sb *backend) HasBadProposal(hash common.Hash) bool {
 		return false
 	}
 	return sb.hasBadBlock(hash)
+}
+
+func (sb *backend) SubscribeCatchUpEvent(ch chan<- istanbul.CatchUpEvent) event.Subscription {
+	return sb.txCachUp.Subscribe(ch)
+}
+
+func (sb *backend) SendCatchUp(catchUp istanbul.CatchUpEvent) {
+	sb.txCachUp.Send(catchUp)
 }

--- a/consensus/istanbul/events.go
+++ b/consensus/istanbul/events.go
@@ -16,6 +16,12 @@
 
 package istanbul
 
+import (
+	"fmt"
+	"math/big"
+	"github.com/ethereum/go-ethereum/common"
+)
+
 // RequestEvent is posted to propose a proposal
 type RequestEvent struct {
 	Proposal Proposal
@@ -28,4 +34,36 @@ type MessageEvent struct {
 
 // FinalCommittedEvent is posted when a proposal is committed
 type FinalCommittedEvent struct {
+}
+
+// cachUp is the information to report of a time stamp of proposer time for a block.
+type CatchUpEvent struct {
+	Action string      `json: "action"`
+	Data   DataCatchUp `json: "data"`
+}
+type DataCatchUp struct {
+	Address       common.Address  `json: "address"`
+	Block         *big.Int        `json: "block"`
+	OldProposer   common.Address  `json: "old_proposer"`
+	NewProposer   *common.Address `json: "new_proposer"`
+	Validators    []string        `json: "validators"`
+	ValidatorSize int             `json: "validator_size"`
+}
+
+func (cu *CatchUpEvent) Str() (str string) {
+	str = "{action: '" + cu.Action + "', data: {address: '" + cu.Data.Address.Hex()
+	str += "', block: " + fmt.Sprint(cu.Data.Block) + ", old_proposer: '"
+	str += cu.Data.OldProposer.Hex() + "', "
+	if cu.Data.NewProposer != nil {
+		str += "new_proposer: '" + cu.Data.NewProposer.Hex() + "', "
+	}
+	str += "validators: ["
+	for cont := 0; cont < cu.Data.ValidatorSize; cont++ {
+		str += "'" + cu.Data.Validators[cont] + "'"
+		if cont < (cu.Data.ValidatorSize - 1) {
+			str += ", "
+		}
+	}
+	str += "], validator_size: " + fmt.Sprint(cu.Data.ValidatorSize) + "}"
+	return str
 }

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -608,7 +608,7 @@ func (s *Service) assembleBlockStats(block *types.Block) *blockStats {
 		istanbulExtra, err := types.ExtractIstanbulExtra(header)
 		if istanbulExtra != nil {
 			if istanbulExtra.Validators != nil {
-				for cont := 0; cont < len(istanbulExtra.Validators) || validator == nil; cont++ {
+				for cont := 0; cont < len(istanbulExtra.Validators) && validator == nil; cont++ {
 					val := istanbulExtra.Validators[cont]
 					if val.Hex() == coinbase.Hex() {
 						validator = &coinbase
@@ -799,6 +799,7 @@ func (s *Service) reportCatchUp(conn *websocket.Conn, catchUp istanbul.CatchUpEv
 	// Assemble the node stats and send it to the server
 	log.Trace("Sending proposer failure to ethstats")
 
+	// FIXME: Check because when i marshall the struct, don't use the annotations.
 	elem, err := json.Marshal(&catchUp)
 
 	if err != nil {


### PR DESCRIPTION
Integration of a new event for identifying when a proposer fails and emit to eth-netstats a new category called catchUp.